### PR TITLE
Hiding error prints while oracle is running comprehensive tests and hotfix model zero outputs

### DIFF
--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -739,9 +739,9 @@ class Evaluation:
             num_successes = 0
             num_errors = 0
             sum_failing_scores = 0.0
-            from utils.hidden_prints import HiddenPrints
+            from utils.hidden_prints import HiddenPrintsHiddenErrors
 
-            with HiddenPrints():
+            with HiddenPrintsHiddenErrors():
                 for instance_id in instance_ids:
                     row_num = instance_id - first_instance_id
 
@@ -784,6 +784,10 @@ class Evaluation:
 
                     # get the resulting answers after our model outputs
                     model_outputs = self.extract_values(inputs)
+
+                    # Hack in case model_outputs is zero, treat this as an error so don't divide by zero later
+                    if len(model_outputs) == 0:
+                        error_flag = True
 
                     if error_flag:
                         num_errors += 1

--- a/src/utils/hidden_prints.py
+++ b/src/utils/hidden_prints.py
@@ -8,3 +8,14 @@ class HiddenPrints:
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout.close()
         sys.stdout = self._original_stdout
+
+class HiddenPrintsHiddenErrors:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # This is a natural exit leaving the scope instead of an error/exception happening
+        if exc_type is None and exc_val is None and exc_tb is None:
+            sys.stdout.close()
+            sys.stdout = self._original_stdout


### PR DESCRIPTION
I also went ahead and sent a PR to Yeganeh's fork of Turkle to disable HTTP logging since it clutters the output space
https://github.com/yeganehkordi/turkle/pull/3

@danyaljj 