### PR TITLE
Parallelization and hotfixes of TAP tests

### DIFF
--- a/.github/workflows/tap_test.yml
+++ b/.github/workflows/tap_test.yml
@@ -49,4 +49,4 @@ jobs:
       - name: run TAP tests
         run: |
           echo 'run TAP tests ${{ matrix.tap }}'
-          python TAP_tests.py ${{ matrix.tap }}
+          python src/TAP_tests.py ${{ matrix.tap }}

--- a/.github/workflows/tap_test.yml
+++ b/.github/workflows/tap_test.yml
@@ -10,6 +10,11 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        tap: [tap1, tap2, tap3, tap4, tap5, tap6, tap7, tap8, tap9, tap10, tap11, tap12, tap13, tap14, tap15, tap16, tap17, tap18, tap19]
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -39,5 +44,8 @@ jobs:
           python 2_generate_input_csv.py
           echo 'Upload the tasks'
           python 3_upload_tasks.py
-          echo 'run comprehensive tests'
-          python comprehensive_test.py
+
+      # Run the TAP tests
+      - name: run TAP tests
+          echo 'run TAP tests ${{ matrix.tap }}'
+          python TAP_tests.py ${{ matrix.tap }}

--- a/.github/workflows/tap_test.yml
+++ b/.github/workflows/tap_test.yml
@@ -48,5 +48,6 @@ jobs:
       # Run the TAP tests
       - name: run TAP tests
         run: |
+          cd src
           echo 'run TAP tests ${{ matrix.tap }}'
-          python src/TAP_tests.py ${{ matrix.tap }}
+          python TAP_tests.py ${{ matrix.tap }}

--- a/.github/workflows/tap_test.yml
+++ b/.github/workflows/tap_test.yml
@@ -47,5 +47,6 @@ jobs:
 
       # Run the TAP tests
       - name: run TAP tests
+        run: |
           echo 'run TAP tests ${{ matrix.tap }}'
           python TAP_tests.py ${{ matrix.tap }}

--- a/.github/workflows/tap_test.yml
+++ b/.github/workflows/tap_test.yml
@@ -1,4 +1,4 @@
-name: Comprehensive testing of all tasks
+name: TAP tests
 
 on:
   workflow_dispatch:

--- a/src/1_run_website.sh
+++ b/src/1_run_website.sh
@@ -1,4 +1,4 @@
-GIT_URL="https://github.com/yeganehkordi/turkle.git"
+GIT_URL="https://github.com/klxu03/turkle.git"
 repo_dir="Turkle"
 
 # choose the right pip/python

--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -91,6 +91,7 @@ class Evaluation:
     def load_tap_task_names(self):
         # load all tasks into a list of strings
         all_tasks = os.listdir("../tasks")
+        all_tasks = filter(lambda task: "sandbox" not in task, all_tasks)
 
         partitions = 19 # number of partitions
         num_per_partition = -(len(all_tasks) // -partitions) # ceil division 

--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -95,6 +95,9 @@ class Evaluation:
 
         partitions = 19 # number of partitions
         num_per_partition = -(len(all_tasks) // -partitions) # ceil division 
+        
+        # Can optimize this with greedy and DP to minimize difference between largest and smallest partition
+        # Start with # of instances * # tasks, then can go # inputs * # instances * # tasks
         split_tasks = [all_tasks[i * num_per_partition : (i + 1) * num_per_partition] for i in range(partitions)] 
 
         ind = int(self.tasks[len("tap"):])

--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -102,7 +102,6 @@ class Evaluation:
         split_tasks = [all_tasks[i * num_per_partition : (i + 1) * num_per_partition] for i in range(partitions)] 
 
         ind = int(self.tasks[len("tap"):]) - 1
-        print("ind", ind)
 
         print("tap tasks", split_tasks[ind])
         return split_tasks[ind]

--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -56,7 +56,7 @@ class Evaluation:
         else:
             raise Exception(f"{Fore.RED}Solver `{solver_type}` not implemented")
         self.tasks = tasks
-        assert tasks in ["test", "train", "all", "subjective_test"]
+        assert tasks in ["test", "train", "all", "subjective_test"] or tasks.startswith("tap")
 
         self.do_eval = do_eval
         self.dump_features = dump_features
@@ -87,6 +87,20 @@ class Evaluation:
             driver = webdriver.Firefox()
 
         return driver
+
+    def load_tap_task_names(self):
+        # load all tasks into a list of strings
+        all_tasks = os.listdir("../tasks")
+
+        partitions = 19 # number of partitions
+        num_per_partition = -(len(all_tasks) // -partitions) # ceil division 
+        split_tasks = [all_tasks[i * num_per_partition : (i + 1) * num_per_partition] for i in range(partitions)] 
+
+        ind = int(self.tasks[len("tap"):])
+        print("ind", ind)
+
+        print("tap tasks", split_tasks[ind])
+        return split_tasks[ind]
 
     def load_task_names(self):
         """
@@ -708,7 +722,7 @@ class Evaluation:
         print("----------------------------------------------")
         print(f'Field statistics per task: {task_field_statistics}')
 
-    def enumerate_comprehensive_tasks(self, max_instance_count: int):
+    def enumerate_tap_tasks(self, max_instance_count: int):
         """
         Enumerate all the tasks comprehensively, so going upto max_instance_count which should be high
         It will keep going despite failures and errors (and not skip any available tasks)
@@ -723,7 +737,7 @@ class Evaluation:
 
         input_format = "both"
 
-        tasks = self.load_task_names()
+        tasks = self.load_tap_task_names()
         ret = []
         self.driver.get(TURKLE_URL)
 

--- a/src/4_run_evaluation.py
+++ b/src/4_run_evaluation.py
@@ -91,7 +91,8 @@ class Evaluation:
     def load_tap_task_names(self):
         # load all tasks into a list of strings
         all_tasks = os.listdir("../tasks")
-        all_tasks = filter(lambda task: "sandbox" not in task, all_tasks)
+        all_tasks = list(filter(lambda task: "sandbox" not in task, all_tasks))
+        print("all_tasks len:", len(all_tasks))
 
         partitions = 19 # number of partitions
         num_per_partition = -(len(all_tasks) // -partitions) # ceil division 

--- a/src/TAP_tests.py
+++ b/src/TAP_tests.py
@@ -2,6 +2,7 @@ eval = __import__('4_run_evaluation')
 from evaluation.actions import MyActions
 from evaluation.baselines import Baseline
 from utils.hidden_prints import HiddenPrints
+import sys
 
 evaluation = eval.Evaluation(solver_type="oracle", tasks="all",
                              do_eval=True, dump_features=True, report_field_stats=True)
@@ -9,7 +10,7 @@ evaluation = eval.Evaluation(solver_type="oracle", tasks="all",
 
 def test_evaluation():
     # dictionary mapping {task_name, {num_successes, num_errors, num_failing, sum_failing_scores} }
-    results = evaluation.enumerate_comprehensive_tasks(max_instance_count=1000) # dictionary of results
+    results = evaluation.enumerate_tap_tasks(max_instance_count=1000) # dictionary of results
 
     # Global statistics
     tasks_succeeded = 0
@@ -30,4 +31,5 @@ def test_evaluation():
 
 if __name__ == "__main__":
     print("Running comprehensive tests")
+    evaluation.tasks = sys.argv[1]
     test_evaluation()

--- a/src/TAP_tests.py
+++ b/src/TAP_tests.py
@@ -26,8 +26,7 @@ def test_evaluation():
         else:
             tasks_failed += 1
 
-        print(f"task: {task} | num_successes: {result['num_successes']} | num_errors: {result['num_errors']} | num_failing: {result['num_failing']} | sum_failing_scores: {result['sum_failing_scores']}")
-        print(f"result: {result}")
+        print(f"task: {task} | result: {result}")
 
 if __name__ == "__main__":
     print("Running comprehensive tests")


### PR DESCRIPTION
I parallelized the runtime for TAP tests (formerly comprehensive tests) so now it can run through up to 1000 instances of each task in under 3 hours. 

@danyaljj 